### PR TITLE
最終行の指定をイベントのステータスで行えるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ $ cp .clasp.example.json .clasp.json
 |:---:|:---:|:---:|
 |EXECUTE_STATUS_VALUE|登録, 更新を実行する対象の値|`登録/更新する`|
 |ADDED_STATUS_VALUE|実行完了後の値|`登録完了`|
+|LAST_ROW_STATUS_VALUE|最終行の値. イベントにこれがセットされていると, その行で終了する.|`最終行`|
 |BASE_SHEET_NAME|データの入ったシート名|`勤務データ`|
 
 ### イベント登録で使うプロパティの設定

--- a/src/application.ts
+++ b/src/application.ts
@@ -31,6 +31,10 @@ export class Application {
     for (let rowNumber = 2; rowNumber <= sheet.getLastRow(); rowNumber++) {
       const settings = this.loadSettings(sheet, rowNumber);
 
+      if (settings.event.status === this.options.lastRowStatusValue) {
+        break;
+      }
+
       if (settings.event.status === this.options.executeStatusValue) {
         this.registerEvent(settings);
       }

--- a/src/application.ts
+++ b/src/application.ts
@@ -349,6 +349,8 @@ export function start (): void {
   const executeStatusValue = scriptProperties.getProperty('EXECUTE_STATUS_VALUE');
   // 実行完了後にセットする status の値
   const addedStatusValue = scriptProperties.getProperty('ADDED_STATUS_VALUE');
+  // 最終行の status の値
+  const lastRowStatusValue = scriptProperties.getProperty('LAST_ROW_STATUS_VALUE');
 
   // 登録するカレンダーの ID
   const calendarId = scriptProperties.getProperty('CALENDAR_ID');
@@ -383,6 +385,7 @@ export function start (): void {
     sheetName: baseSheetName,
     executeStatusValue: executeStatusValue,
     addedStatusValue: addedStatusValue,
+    lastRowStatusValue: lastRowStatusValue,
     event: eventOptions,
     task: taskOptions,
   };

--- a/types/application.d.ts
+++ b/types/application.d.ts
@@ -4,6 +4,7 @@ export interface ApplicationOptions {
   sheetName: string;
   executeStatusValue: string;
   addedStatusValue: string;
+  lastRowStatusValue: string;
   event: EventOptions;
   task: TaskOptions;
 }


### PR DESCRIPTION
シートの `getLastRow()` の値まで回すと実行時間が勿体ないので, 最終行の指定をイベントのステータスで行えるようにする.

イベントのステータスが `LAST_ROW_STATUS_VALUE` の値だった場合は, そこで終了ように変更.