### PR TITLE
登録を開始する行をプロパティで指定できるように改修

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ $ cp .clasp.example.json .clasp.json
 |ADDED_STATUS_VALUE|実行完了後の値|`登録完了`|
 |LAST_ROW_STATUS_VALUE|最終行の値. イベントにこれがセットされていると, その行で終了する.|`最終行`|
 |BASE_SHEET_NAME|データの入ったシート名|`勤務データ`|
+|START_LINE|開始する行．2以上の値．|`2`|
 
 ### イベント登録で使うプロパティの設定
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -27,8 +27,9 @@ export class Application {
    */
   start (): void {
     const sheet = this.getSheet();
+    const startLine = this.options.startLine;
 
-    for (let rowNumber = 2; rowNumber <= sheet.getLastRow(); rowNumber++) {
+    for (let rowNumber = startLine; rowNumber <= sheet.getLastRow(); rowNumber++) {
       const settings = this.loadSettings(sheet, rowNumber);
 
       if (settings.event.status === this.options.lastRowStatusValue) {

--- a/src/application.ts
+++ b/src/application.ts
@@ -349,6 +349,8 @@ export function start (): void {
 
   // データの入ったシート名
   const baseSheetName = scriptProperties.getProperty('BASE_SHEET_NAME');
+  // 最終行の status の値
+  const startLine = +scriptProperties.getProperty('START_LINE');
   // 実行する status の値
   const executeStatusValue = scriptProperties.getProperty('EXECUTE_STATUS_VALUE');
   // 実行完了後にセットする status の値
@@ -387,6 +389,7 @@ export function start (): void {
 
   const applicationOptions: ApplicationOptions = {
     sheetName: baseSheetName,
+    startLine: startLine,
     executeStatusValue: executeStatusValue,
     addedStatusValue: addedStatusValue,
     lastRowStatusValue: lastRowStatusValue,

--- a/types/application.d.ts
+++ b/types/application.d.ts
@@ -5,6 +5,7 @@ export interface ApplicationOptions {
   executeStatusValue: string;
   addedStatusValue: string;
   lastRowStatusValue: string;
+  startLine: number;
   event: EventOptions;
   task: TaskOptions;
 }


### PR DESCRIPTION
登録を開始する行をプロパティで指定できるように改修．
更新しない200行を見て回るのは非効率すぎるので途中から登録できるようにする．